### PR TITLE
Add four new projects and disclose Crashlytics in Sumo privacy policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,39 @@
         <div class="grid">
 
           <div class="card">
+            <h3><a href="/support/sumo.html">Sumo</a></h3>
+            <p>Virtual-pet learning game for iOS. A child opens a mystery pack and cares for its
+            mascot by completing short bursts of multiple-choice math problems, with invisibly
+            adaptive difficulty. Local-only, no accounts, no ads — a cheerful pixel-art
+            experience for ages 4–12.</p>
+            <div class="tags"><span class="tag">iOS</span><span class="tag">SwiftUI</span><span class="tag">Education</span><span class="tag">Kids</span></div>
+          </div>
+
+          <div class="card">
+            <h3>Turn Siege</h3>
+            <p>Fast-loading, bite-sized isometric defense game built with Godot 4. Your gas
+            station sits on a four-front battlefield but you can only cover the two fronts
+            facing you — swipe to spin the view and bring your guns to bear. Fully procedural
+            graphics and daily streak rewards.</p>
+            <div class="tags"><span class="tag">Godot</span><span class="tag">Game Dev</span><span class="tag">iOS</span></div>
+          </div>
+
+          <div class="card">
+            <h3><a href="https://github.com/gelemias/mdoc-verifier" target="_blank" rel="noopener">mdoc-verifier</a></h3>
+            <p>Open-source FastAPI demo verifier for ISO 18013 web retrieval flows — generates
+            <code>mdoc://</code> QR deep links, derives session keys and exchanges encrypted CBOR
+            DeviceRequests to test wallet interoperability for PhotoID-style requests.</p>
+            <div class="tags"><span class="tag">Open Source</span><span class="tag">Python</span><span class="tag">ISO 18013</span><span class="tag">Digital Identity</span></div>
+          </div>
+
+          <div class="card">
+            <h3><a href="https://github.com/gelemias/b64img" target="_blank" rel="noopener">b64img</a></h3>
+            <p>Simple, no-frills base64 image decoder — paste an encoded string, get your
+            image back.</p>
+            <div class="tags"><span class="tag">Open Source</span><span class="tag">Utility</span></div>
+          </div>
+
+          <div class="card">
             <h3><a href="https://apps.apple.com/pl/app/ips-id-wallet/id6758149983" target="_blank" rel="noopener">ID Wallet</a></h3>
             <p>Secure digital identity wallet for managing verifiable credentials and identity
             documents — identity proofing through document scanning, NFC passport/ID verification

--- a/privacy/sumo.html
+++ b/privacy/sumo.html
@@ -29,20 +29,36 @@
       developed by Guillermo Rodriguez Delgado.</p>
 
       <h2>Data collection</h2>
-      <p>Sumo does not collect, store or transmit any personal data. All app data
-      stays on your device (and in your personal iCloud account if you enable
-      device backups or syncing, which are managed entirely by Apple).</p>
+      <p>Sumo does not collect personal data. There are no accounts, no ads and
+      no tracking. All game progress stays on your device (and in your personal
+      iCloud account if you enable device backups, which are managed entirely
+      by Apple).</p>
+
+      <h2>Crash reporting</h2>
+      <p>To keep the app stable, Sumo uses Firebase Crashlytics (a Google
+      service) to receive anonymous crash reports and diagnostic information
+      when the app malfunctions. These reports describe the state of the app at
+      the time of a crash — they do not include names, contact details, game
+      content or anything typed into the app, and they are not used for
+      advertising or tracking. Crash data is used solely to diagnose and fix
+      problems.</p>
 
       <h2>Third-party services</h2>
-      <p>Sumo does not use third-party analytics, advertising frameworks or
-      tracking tools of any kind.</p>
+      <p>Apart from Firebase Crashlytics (crash reporting only, described
+      above), Sumo does not use third-party analytics, advertising frameworks
+      or tracking tools of any kind.</p>
 
       <h2>Data sharing</h2>
-      <p>Since no data is collected, no data is shared with third parties.</p>
+      <p>No personal data is collected, so none is sold or shared. Anonymous
+      crash reports are processed by Google Firebase on my behalf, subject to
+      <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Google's
+      Firebase privacy documentation</a>.</p>
 
       <h2>Children's privacy</h2>
-      <p>Sumo does not collect data from anyone, including children under the
-      age of 13.</p>
+      <p>Sumo is designed for children and takes their privacy seriously: it
+      does not collect personal data from anyone, including children under the
+      age of 13. There are no accounts, no social features, no ads and no
+      third-party tracking.</p>
 
       <h2>Changes to this policy</h2>
       <p>If the app's data practices ever change, this policy will be updated


### PR DESCRIPTION
- Portfolio: add Sumo, Turn Siege, mdoc-verifier and b64img cards at the top of the projects grid (GitHub links only for the public repos)
- Sumo privacy policy: disclose Firebase Crashlytics crash reporting, since the app uses it in production builds — policy must match App Privacy answers


Claude-Session: https://claude.ai/code/session_01RBj7PRFeojdRAAU7WFzTn9