### PR TITLE
Modernize portfolio, add App Store privacy/support pages, refresh content

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,12 +51,17 @@
       <div class="container">
         <h2 class="section-title">About</h2>
         <p class="section-lead">
-          Experienced engineer with over 14 years in commercial business, designing, building
-          and scaling high-quality applications. Currently leading iOS at IDEMIA, owning technical
-          decisions around performance, security and long-term maintainability for large-scale
-          digital identity solutions. I invest time and effort in the cutting edge of software
-          development, with a strong focus on UI — building custom elements and controls that fit
-          the right approach to each specific need.
+          I've spent 14+ years building mobile software, and these days I lead iOS at IDEMIA,
+          designing the architecture behind government-grade digital identity — wallets,
+          verifiable credentials and ISO 18013 mDoc flows, where security, performance and
+          long-term maintainability aren't features but the product itself.
+        </p>
+        <p class="section-lead">
+          After hours I keep the craft playful: a pixel-art virtual pet that teaches kids math
+          in SwiftUI, an isometric defense game in Godot, and open-source tooling for testing
+          identity-wallet interoperability. Whatever the project, the through-line is the same —
+          a strong focus on UI and custom-built components, choosing the right approach for each
+          specific need rather than the fashionable one.
         </p>
       </div>
     </section>
@@ -258,13 +263,26 @@
           <h3>Mobile &amp; Languages</h3>
           <div class="chips">
             <span class="chip">Swift</span>
+            <span class="chip">SwiftUI</span>
             <span class="chip">Objective-C</span>
             <span class="chip">Cocoa Touch</span>
-            <span class="chip">SpriteKit</span>
+            <span class="chip">Python</span>
             <span class="chip">C#</span>
             <span class="chip">C++</span>
-            <span class="chip">WPF</span>
             <span class="chip">JavaScript</span>
+          </div>
+        </div>
+
+        <div class="chip-group">
+          <h3>Digital Identity &amp; Security</h3>
+          <div class="chips">
+            <span class="chip">ISO/IEC 18013 (mDL / mDoc)</span>
+            <span class="chip">Verifiable Credentials</span>
+            <span class="chip">NFC Document Verification</span>
+            <span class="chip">Biometric Authentication</span>
+            <span class="chip">CBOR</span>
+            <span class="chip">Applied Cryptography</span>
+            <span class="chip">Secure Architecture</span>
           </div>
         </div>
 
@@ -272,7 +290,6 @@
           <h3>Engineering practices</h3>
           <div class="chips">
             <span class="chip">Software Architecture</span>
-            <span class="chip">Security</span>
             <span class="chip">Performance &amp; High Availability</span>
             <span class="chip">Unit Testing</span>
             <span class="chip">TDD / BDD</span>
@@ -284,13 +301,16 @@
         </div>
 
         <div class="chip-group">
-          <h3>Design</h3>
+          <h3>Games &amp; Design</h3>
           <div class="chips">
-            <span class="chip">User Experience Design</span>
+            <span class="chip">Godot 4</span>
+            <span class="chip">SpriteKit</span>
+            <span class="chip">Procedural Graphics</span>
+            <span class="chip">Design Systems</span>
             <span class="chip">Custom UI Components</span>
-            <span class="chip">Graphic Design</span>
-            <span class="chip">Photoshop</span>
-            <span class="chip">Illustrator</span>
+            <span class="chip">User Experience Design</span>
+            <span class="chip">Pixel Art</span>
+            <span class="chip">Photoshop / Illustrator</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- Converts the site to a dependency-free static build (`.nojekyll`) by removing gulp/browser-sync/yarn.lock, Gemfile and Jekyll templates — this eliminates all Dependabot vulnerability alerts (130 open, including advisories in axios, ws, form-data, decompress and concurrent-ruby), since there's no dependency tree left to scan
- New responsive design with automatic dark/light mode and a self-contained stylesheet (no external CDNs)
- Updates CV content from the latest resume: current IDEMIA Mobile Architect role, full experience timeline, ID Wallet and Mobile ID projects
- Adds `privacy/` and `support/` page trees (general index + per-app pages + a reusable app template) for App Store Connect submissions
- Adds four recently created projects to the portfolio grid: Sumo, Turn Siege, mdoc-verifier and b64img
- Reworks the About and Skills sections to reflect current work — digital identity architecture (ISO 18013/mDoc, verifiable credentials) alongside indie projects (SwiftUI, Godot)
- Updates Sumo's privacy policy to disclose Firebase Crashlytics crash reporting, matching the app's actual behavior

## Test plan

- [x] Verified all pages (`/`, `/privacy/`, `/privacy/sumo.html`, `/support/`, etc.) return 200 via local static server
- [x] Screenshot-tested the homepage and privacy pages in both light and dark color schemes
- [x] Screenshot-tested the updated Projects, About and Skills sections
- [x] Confirmed no `package.json`/lockfiles/Gemfile remain in the tree


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBj7PRFeojdRAAU7WFzTn9)_