### PR TITLE
Redesign portfolio: "Telemetry" driver-dossier CV with light/dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gelemias.github.io
 
-Personal website of Guillermo Rodriguez Delgado — iOS Software Engineer & Mobile Architect.
+Personal website of Guillermo Rodríguez Delgado — iOS Software Engineer & Mobile Architect.
 
 Plain static HTML/CSS site served by GitHub Pages — no build step, no dependencies
 (`.nojekyll` disables the Jekyll build entirely).

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,8 +15,10 @@
   --muted:    #8d8f9c;
   --muted-2:  #62636e;
 
-  --volt:     #d7ff2e;   /* accent (text/lines/glyphs) — darkens in light mode */
-  --volt-fill:#d7ff2e;   /* neon block-fill — stays bright under dark text */
+  --volt:     #d7ff2e;   /* signature neon — same in both themes */
+  --volt-fill:#d7ff2e;   /* neon block-fill / highlight — under dark text */
+  --accent:   var(--volt); /* plain accent TEXT — volt on dark, ink on light */
+  --ink-on-volt: #0a0a06;  /* foreground on a volt highlight */
   --volt-dim: #a9c922;
   --signal:   #ff3b2e;   /* racing red — used sparingly */
   --cyan:     #26e0e0;
@@ -50,9 +52,10 @@
   --text:     #15150f;
   --muted:    #55564c;
   --muted-2:  #77786c;
-  --volt:     #4a6800;   /* readable deep-green accent */
-  --volt-dim: #3c5500;
-  --cyan:     #0b7c8e;
+  --volt:     #d7ff2e;   /* keep the neon; used as highlight + on dark panels */
+  --volt-dim: #a9c922;
+  --accent:   #17170f;   /* plain accent text becomes ink on light */
+  --cyan:     #0b7c8e;   /* readable teal for inline code on light */
   --glow-a:   #dfff8a;
   --glow-b:   #cdeff2;
   color-scheme: light;
@@ -68,8 +71,9 @@
     --text:     #15150f;
     --muted:    #55564c;
     --muted-2:  #77786c;
-    --volt:     #4a6800;
-    --volt-dim: #3c5500;
+    --volt:     #d7ff2e;
+    --volt-dim: #a9c922;
+    --accent:   #17170f;
     --cyan:     #0b7c8e;
     --glow-a:   #dfff8a;
     --glow-b:   #cdeff2;
@@ -117,7 +121,7 @@ body::after {                  /* film grain */
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
-a { color: var(--volt); text-decoration: none; }
+a { color: var(--accent); text-decoration: none; }
 img { max-width: 100%; display: block; }
 
 .container {
@@ -161,7 +165,7 @@ img { max-width: 100%; display: block; }
   font-family: var(--font-mono);
   font-size: 0.62rem;
   letter-spacing: 0.12em;
-  color: var(--volt);
+  color: var(--accent);
   transform: translateY(-2px);
 }
 .nav-links { display: flex; gap: 26px; }
@@ -184,7 +188,7 @@ img { max-width: 100%; display: block; }
 .nav-links a:hover,
 .nav-links a.active { color: var(--text); }
 .nav-links a:hover::before,
-.nav-links a.active::before { color: var(--volt); }
+.nav-links a.active::before { color: var(--accent); }
 
 .nav-status {
   display: inline-flex;
@@ -212,7 +216,7 @@ img { max-width: 100%; display: block; }
   cursor: pointer;
   transition: border-color 0.2s var(--ease), color 0.2s var(--ease), transform 0.2s var(--ease);
 }
-.theme-toggle:hover { border-color: var(--volt); color: var(--volt); transform: translateY(-1px); }
+.theme-toggle:hover { border-color: var(--volt); color: var(--accent); transform: translateY(-1px); }
 .theme-toggle svg { width: 16px; height: 16px; fill: currentColor; }
 .theme-toggle .i-sun { display: none; }
 .theme-toggle .i-moon { display: block; }
@@ -315,7 +319,15 @@ img { max-width: 100%; display: block; }
   margin-bottom: 26px;
 }
 .hero-kicker .bar { width: 34px; height: 1px; background: var(--volt); }
-.hero-kicker b { color: var(--volt); font-weight: 600; }
+.hero-kicker b {
+  color: var(--ink-on-volt);
+  background: var(--volt);
+  font-weight: 600;
+  padding: 0 0.32em;
+  border-radius: 3px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
 
 .hero-name {
   font-family: var(--font-display);
@@ -326,7 +338,8 @@ img { max-width: 100%; display: block; }
   margin: 0;
   font-size: clamp(3.4rem, 15vw, 12rem);
 }
-.hero-name .l1 { display: block; color: var(--text); }
+.hero-name .l1,
+.hero-name .l3 { display: block; color: var(--text); }
 .hero-name .l2 {
   display: block;
   color: transparent;
@@ -334,8 +347,8 @@ img { max-width: 100%; display: block; }
   transition: -webkit-text-stroke-color 0.4s var(--ease), color 0.4s var(--ease);
 }
 .hero:hover .hero-name .l2 {
-  color: var(--volt);
-  -webkit-text-stroke-color: var(--volt);
+  color: var(--accent);
+  -webkit-text-stroke-color: var(--accent);
 }
 
 .hero-role {
@@ -349,7 +362,7 @@ img { max-width: 100%; display: block; }
 .hero-role .cursor {
   display: inline-block;
   width: 10px;
-  background: var(--volt);
+  background: var(--accent);
   margin-left: 2px;
   animation: blink 1s steps(1) infinite;
 }
@@ -367,7 +380,7 @@ img { max-width: 100%; display: block; }
   text-transform: uppercase;
 }
 .hero-meta span { display: inline-flex; align-items: center; gap: 8px; }
-.hero-meta span::before { content: "//"; color: var(--volt); }
+.hero-meta span::before { content: "//"; color: var(--accent); }
 
 .hero-cta { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 40px; }
 
@@ -437,7 +450,7 @@ section { position: relative; padding: 96px 0; }
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--volt);
+  color: var(--accent);
   margin-bottom: 16px;
 }
 .sec-tag .num { color: var(--muted-2); }
@@ -480,7 +493,7 @@ section { position: relative; padding: 96px 0; }
   font-family: var(--font-display);
   font-size: clamp(2.6rem, 6vw, 4rem);
   line-height: 1;
-  color: var(--volt);
+  color: var(--accent);
   letter-spacing: 0.01em;
 }
 .stat-num .suffix { color: var(--text); }
@@ -527,7 +540,7 @@ section { position: relative; padding: 96px 0; }
 .dossier-meta .row:last-child { border-bottom: none; }
 .dossier-meta .k { color: var(--muted-2); letter-spacing: 0.06em; text-transform: uppercase; font-size: 0.68rem; }
 .dossier-meta .v { color: var(--text); text-align: right; }
-.dossier-meta .v.on { color: var(--volt); }
+.dossier-meta .v.on { color: var(--accent); }
 .dossier-body p {
   font-size: 1.12rem;
   line-height: 1.7;
@@ -537,9 +550,13 @@ section { position: relative; padding: 96px 0; }
 .dossier-body p:last-child { margin-bottom: 0; }
 .dossier-body strong { color: var(--text); font-weight: 600; }
 .dossier-body .hl {
-  color: var(--volt);
+  color: var(--ink-on-volt);
+  background: var(--volt);
   font-weight: 600;
-  border-bottom: 1px solid color-mix(in srgb, var(--volt) 40%, transparent);
+  padding: 0 0.24em;
+  border-radius: 3px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 /* ==========================================================================
@@ -563,7 +580,7 @@ section { position: relative; padding: 96px 0; }
   -webkit-text-stroke: 1px var(--line-2);
   transition: -webkit-text-stroke-color 0.3s var(--ease), color 0.3s var(--ease);
 }
-.lap:hover .lap-num { color: var(--volt); -webkit-text-stroke-color: var(--volt); }
+.lap:hover .lap-num { color: var(--accent); -webkit-text-stroke-color: var(--accent); }
 .lap-role {
   font-family: var(--font-sans);
   font-size: 1.4rem;
@@ -581,7 +598,7 @@ section { position: relative; padding: 96px 0; }
   flex-wrap: wrap;
   gap: 6px 14px;
 }
-.lap-meta .co { color: var(--volt); }
+.lap-meta .co { color: var(--accent); }
 .lap-meta .split {
   margin-left: auto;
   color: var(--text);
@@ -601,7 +618,7 @@ section { position: relative; padding: 96px 0; }
   content: "›";
   position: absolute;
   left: 4px;
-  color: var(--volt);
+  color: var(--accent);
   font-weight: 700;
 }
 
@@ -671,7 +688,7 @@ section { position: relative; padding: 96px 0; }
 }
 .card h3 { margin: 0 0 10px; font-size: 1.16rem; font-weight: 600; letter-spacing: -0.01em; }
 .card h3 a { color: var(--text); }
-.card h3 a:hover { color: var(--volt); }
+.card h3 a:hover { color: var(--accent); }
 .card h3 .ext { font-size: 0.7rem; color: var(--muted-2); margin-left: 6px; }
 .card p { margin: 0 0 18px; color: var(--muted); font-size: 0.93rem; flex: 1; }
 .card code {
@@ -735,16 +752,17 @@ section { position: relative; padding: 96px 0; }
   align-items: center;
   justify-content: center;
   gap: 12px;
+  /* always a dark HUD panel so the neon glyph reads in both themes */
   background:
-    radial-gradient(circle at 50% 42%, color-mix(in srgb, var(--volt) 14%, transparent), transparent 68%),
-    repeating-linear-gradient(90deg, var(--line) 0 1px, transparent 1px 40px),
-    var(--surface-2);
+    radial-gradient(circle at 50% 42%, color-mix(in srgb, var(--volt) 16%, transparent), transparent 68%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.06) 0 1px, transparent 1px 40px),
+    #101015;
 }
 .card-media.ph-id {
   background:
-    radial-gradient(circle at 50% 42%, color-mix(in srgb, var(--cyan) 16%, transparent), transparent 68%),
-    repeating-linear-gradient(90deg, var(--line) 0 1px, transparent 1px 40px),
-    var(--surface-2);
+    radial-gradient(circle at 50% 42%, color-mix(in srgb, #26e0e0 18%, transparent), transparent 68%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.06) 0 1px, transparent 1px 40px),
+    #101015;
 }
 .ph-glyph {
   font-family: var(--font-mono);
@@ -753,13 +771,13 @@ section { position: relative; padding: 96px 0; }
   color: var(--volt);
   text-shadow: 0 0 24px color-mix(in srgb, var(--volt) 55%, transparent);
 }
-.ph-id .ph-glyph { color: var(--cyan); text-shadow: 0 0 24px color-mix(in srgb, var(--cyan) 55%, transparent); }
+.ph-id .ph-glyph { color: #26e0e0; text-shadow: 0 0 24px color-mix(in srgb, #26e0e0 55%, transparent); }
 .ph-label {
   font-family: var(--font-mono);
   font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: rgba(233, 234, 240, 0.55);   /* on the dark panel, both themes */
 }
 .card-body {
   display: flex;
@@ -789,7 +807,7 @@ section { position: relative; padding: 96px 0; }
   align-items: center;
   gap: 12px;
 }
-.spec-group > h3::before { content: ""; width: 8px; height: 8px; background: var(--volt); transform: rotate(45deg); }
+.spec-group > h3::before { content: ""; width: 8px; height: 8px; background: var(--accent); transform: rotate(45deg); }
 .chips { display: flex; flex-wrap: wrap; gap: 9px; }
 .chip {
   font-size: 0.86rem;
@@ -800,7 +818,7 @@ section { position: relative; padding: 96px 0; }
   color: var(--text);
   transition: border-color 0.2s var(--ease), color 0.2s var(--ease), transform 0.2s var(--ease);
 }
-.chip:hover { border-color: var(--volt); color: var(--volt); transform: translateY(-2px); }
+.chip:hover { border-color: var(--volt); color: var(--accent); transform: translateY(-2px); }
 
 .cols {
   margin-top: 46px;
@@ -810,7 +828,7 @@ section { position: relative; padding: 96px 0; }
 }
 .cols .card { padding: 26px 24px; }
 .cols .card:hover { transform: translateY(-4px); }
-.cols .card h3 { color: var(--volt); font-family: var(--font-mono); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.cols .card h3 { color: var(--accent); font-family: var(--font-mono); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
 .cols .card p { flex: initial; color: var(--muted); margin-bottom: 12px; }
 .cols .card p:last-child { margin-bottom: 0; }
 .cols .card strong { color: var(--text); }
@@ -827,7 +845,11 @@ section { position: relative; padding: 96px 0; }
   line-height: 0.92;
   margin: 0 0 12px;
 }
-.startline .big a { color: var(--volt); }
+.startline .big a {
+  color: var(--accent);
+  border-bottom: 6px solid var(--volt);
+  padding-bottom: 2px;
+}
 .startline p { color: var(--muted); max-width: 560px; margin: 0 auto 34px; }
 .startline .hero-cta { justify-content: center; }
 .checker {
@@ -856,7 +878,7 @@ section { position: relative; padding: 96px 0; }
 .footer .container { display: flex; flex-wrap: wrap; gap: 18px; align-items: center; justify-content: space-between; }
 .footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 .footer a { color: var(--muted); letter-spacing: 0.04em; }
-.footer a:hover { color: var(--volt); }
+.footer a:hover { color: var(--accent); }
 .footer .love { color: var(--signal); }
 
 /* ==========================================================================
@@ -877,7 +899,8 @@ section { position: relative; padding: 96px 0; }
 .doc .updated { font-family: var(--font-mono); color: var(--muted); font-size: 0.82rem; letter-spacing: 0.04em; margin: 0 0 40px; }
 .doc h2 { font-size: 1.25rem; margin: 40px 0 12px; }
 .doc p, .doc li { color: var(--muted); }
-.doc a { color: var(--volt); }
+.doc a { color: var(--accent); border-bottom: 2px solid var(--volt); }
+.doc a:hover { background: color-mix(in srgb, var(--volt) 30%, transparent); }
 .doc ul { padding-left: 20px; }
 .doc .card { margin-top: 14px; background: var(--surface); }
 .doc .card p { flex: initial; margin-bottom: 6px; }
@@ -893,7 +916,7 @@ section { position: relative; padding: 96px 0; }
   margin-bottom: 30px;
   display: inline-block;
 }
-.breadcrumb:hover { color: var(--volt); }
+.breadcrumb:hover { color: var(--accent); }
 
 /* ==========================================================================
    RESPONSIVE

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -336,10 +336,13 @@ img { max-width: 100%; display: block; }
   line-height: 0.86;
   letter-spacing: 0.005em;
   margin: 0;
-  font-size: clamp(3.4rem, 15vw, 12rem);
+  font-size: clamp(3rem, 13vw, 10.5rem);
 }
 .hero-name .l1,
-.hero-name .l3 { display: block; color: var(--text); }
+.hero-name .l2,
+.hero-name .l3 { display: block; white-space: nowrap; }
+.hero-name .l1,
+.hero-name .l3 { color: var(--text); }
 .hero-name .l2 {
   display: block;
   color: transparent;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,10 +15,13 @@
   --muted:    #8d8f9c;
   --muted-2:  #62636e;
 
-  --volt:     #d7ff2e;   /* signature neon — running / urban */
+  --volt:     #d7ff2e;   /* accent (text/lines/glyphs) — darkens in light mode */
+  --volt-fill:#d7ff2e;   /* neon block-fill — stays bright under dark text */
   --volt-dim: #a9c922;
   --signal:   #ff3b2e;   /* racing red — used sparingly */
   --cyan:     #26e0e0;
+  --glow-a:   #d7ff2e;   /* hero ambient glows */
+  --glow-b:   #26e0e0;
 
   --radius:   14px;
   --radius-lg:22px;
@@ -30,6 +33,48 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
   color-scheme: dark;
+}
+
+/* --- LIGHT THEME ---------------------------------------------------------
+   "Concrete + volt": light asphalt/paper, ink text, deep-green accent for
+   text & lines, neon retained on key block-fills (button, ticker, filter).
+   Applied on system preference (unless the user forced dark) and via the
+   HUD toggle (data-theme).                                                */
+:root[data-theme="light"] {
+  --ink:      #f0f0ec;
+  --ink-2:    #e7e7e1;
+  --surface:  #ffffff;
+  --surface-2:#f4f4ef;
+  --line:     rgba(12, 14, 20, 0.10);
+  --line-2:   rgba(12, 14, 20, 0.17);
+  --text:     #15150f;
+  --muted:    #55564c;
+  --muted-2:  #77786c;
+  --volt:     #4a6800;   /* readable deep-green accent */
+  --volt-dim: #3c5500;
+  --cyan:     #0b7c8e;
+  --glow-a:   #dfff8a;
+  --glow-b:   #cdeff2;
+  color-scheme: light;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --ink:      #f0f0ec;
+    --ink-2:    #e7e7e1;
+    --surface:  #ffffff;
+    --surface-2:#f4f4ef;
+    --line:     rgba(12, 14, 20, 0.10);
+    --line-2:   rgba(12, 14, 20, 0.17);
+    --text:     #15150f;
+    --muted:    #55564c;
+    --muted-2:  #77786c;
+    --volt:     #4a6800;
+    --volt-dim: #3c5500;
+    --cyan:     #0b7c8e;
+    --glow-a:   #dfff8a;
+    --glow-b:   #cdeff2;
+    color-scheme: light;
+  }
 }
 
 * { box-sizing: border-box; }
@@ -81,7 +126,7 @@ img { max-width: 100%; display: block; }
   padding: 0 28px;
 }
 
-::selection { background: var(--volt); color: #000; }
+::selection { background: var(--volt-fill); color: #000; }
 
 /* ==========================================================================
    NAV / HUD
@@ -151,6 +196,32 @@ img { max-width: 100%; display: block; }
   color: var(--muted);
 }
 .nav-status .clock { color: var(--text); }
+
+/* theme toggle */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.2s var(--ease), color 0.2s var(--ease), transform 0.2s var(--ease);
+}
+.theme-toggle:hover { border-color: var(--volt); color: var(--volt); transform: translateY(-1px); }
+.theme-toggle svg { width: 16px; height: 16px; fill: currentColor; }
+.theme-toggle .i-sun { display: none; }
+.theme-toggle .i-moon { display: block; }
+:root[data-theme="light"] .theme-toggle .i-sun { display: block; }
+:root[data-theme="light"] .theme-toggle .i-moon { display: none; }
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) .theme-toggle .i-sun { display: block; }
+  :root:not([data-theme="dark"]) .theme-toggle .i-moon { display: none; }
+}
 .status-dot {
   display: inline-flex;
   align-items: center;
@@ -203,10 +274,10 @@ img { max-width: 100%; display: block; }
 .btn svg { width: 16px; height: 16px; fill: currentColor; }
 .btn:hover { transform: translateY(-3px); border-color: var(--line-2); }
 .btn-primary {
-  background: var(--volt);
+  background: var(--volt-fill);
   color: #05050a;
-  border-color: var(--volt);
-  box-shadow: 0 8px 30px -10px var(--volt);
+  border-color: var(--volt-fill);
+  box-shadow: 0 8px 30px -10px var(--volt-fill);
 }
 .btn-primary:hover { box-shadow: 0 14px 40px -10px var(--volt); }
 
@@ -227,8 +298,8 @@ img { max-width: 100%; display: block; }
   pointer-events: none;
   z-index: 0;
 }
-.hero-glow.a { background: var(--volt);  top: -220px; right: -120px; }
-.hero-glow.b { background: var(--cyan);  bottom: -260px; left: -160px; opacity: 0.16; }
+.hero-glow.a { background: var(--glow-a);  top: -220px; right: -120px; }
+.hero-glow.b { background: var(--glow-b);  bottom: -260px; left: -160px; opacity: 0.16; }
 
 .hero .container { position: relative; z-index: 2; }
 
@@ -324,7 +395,7 @@ img { max-width: 100%; display: block; }
    ========================================================================== */
 .ticker {
   border-block: 1px solid #000;
-  background: var(--volt);
+  background: var(--volt-fill);
   overflow: hidden;
   white-space: nowrap;
   transform: rotate(-1.4deg) scale(1.04);
@@ -557,7 +628,7 @@ section { position: relative; padding: 96px 0; }
   transition: color 0.2s var(--ease), border-color 0.2s var(--ease), background 0.2s var(--ease);
 }
 .filter:hover { color: var(--text); border-color: var(--line-2); }
-.filter.active { color: #05050a; background: var(--volt); border-color: var(--volt); }
+.filter.active { color: #05050a; background: var(--volt-fill); border-color: var(--volt-fill); }
 
 .grid {
   display: grid;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,6 +8,38 @@
   var reduceMotion = window.matchMedia &&
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+  /* --- theme toggle (light / dark) ----------------------------------------- */
+  var THEME_KEY = "grd-theme";
+  var root = document.documentElement;
+  var themeMedia = window.matchMedia("(prefers-color-scheme: light)");
+  var themeMeta = document.querySelector('meta[name="theme-color"]');
+
+  var effectiveTheme = function () {
+    var forced = root.getAttribute("data-theme");
+    if (forced) return forced;
+    return themeMedia.matches ? "light" : "dark";
+  };
+  var syncMeta = function () {
+    if (themeMeta) themeMeta.setAttribute("content", effectiveTheme() === "light" ? "#f0f0ec" : "#08080a");
+  };
+  syncMeta();
+
+  var toggle = document.getElementById("themeToggle");
+  if (toggle) {
+    toggle.addEventListener("click", function () {
+      var next = effectiveTheme() === "dark" ? "light" : "dark";
+      try { localStorage.setItem(THEME_KEY, next); } catch (e) {}
+      root.setAttribute("data-theme", next);
+      syncMeta();
+    });
+  }
+  // follow the system when the user hasn't picked a theme
+  themeMedia.addEventListener("change", function () {
+    var stored;
+    try { stored = localStorage.getItem(THEME_KEY); } catch (e) { stored = null; }
+    if (!stored) syncMeta();
+  });
+
   /* --- current year -------------------------------------------------------- */
   var yearEl = document.getElementById("year");
   if (yearEl) yearEl.textContent = String(new Date().getFullYear());

--- a/index.html
+++ b/index.html
@@ -58,8 +58,7 @@
 
         <h1 class="hero-name reveal">
           <span class="l1">Guillermo</span>
-          <span class="l2">Rodríguez</span>
-          <span class="l3">Delgado</span>
+          <span class="l2">R. Delgado</span>
         </h1>
 
         <p class="hero-role reveal" id="typewriter" aria-label="Building government-grade digital identity">

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Guillermo Rodriguez Delgado — iOS Engineer &amp; Mobile Architect</title>
-  <meta name="description" content="Guillermo Rodriguez Delgado — iOS Software Engineer and Mobile Architect with 14+ years building high-quality, secure mobile software. Digital identity, SwiftUI, game dev.">
+  <title>Guillermo Rodríguez Delgado — iOS Engineer &amp; Mobile Architect</title>
+  <meta name="description" content="Guillermo Rodríguez Delgado — iOS Software Engineer and Mobile Architect with 14+ years building high-quality, secure mobile software. Digital identity, SwiftUI, game dev.">
   <meta name="theme-color" content="#08080a">
   <script>try{var t=localStorage.getItem('grd-theme');if(t)document.documentElement.setAttribute('data-theme',t);}catch(e){}</script>
 
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Guillermo Rodriguez Delgado — iOS Engineer &amp; Mobile Architect">
+  <meta property="og:title" content="Guillermo Rodríguez Delgado — iOS Engineer &amp; Mobile Architect">
   <meta property="og:description" content="14+ years building high-quality, secure mobile software. Digital identity, SwiftUI, game dev.">
   <meta property="og:image" content="/assets/img/profile.png">
 
@@ -58,7 +58,8 @@
 
         <h1 class="hero-name reveal">
           <span class="l1">Guillermo</span>
-          <span class="l2">Rodriguez</span>
+          <span class="l2">Rodríguez</span>
+          <span class="l3">Delgado</span>
         </h1>
 
         <p class="hero-role reveal" id="typewriter" aria-label="Building government-grade digital identity">
@@ -501,7 +502,7 @@
   <!-- ============================ FOOTER ============================ -->
   <footer class="footer">
     <div class="container">
-      <p>© <span id="year">2026</span> Guillermo Rodriguez Delgado — Made with <span class="love">❤</span> in Łódź</p>
+      <p>© <span id="year">2026</span> Guillermo Rodríguez Delgado — Made with <span class="love">❤</span> in Łódź</p>
       <nav>
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Guillermo Rodriguez Delgado — iOS Engineer &amp; Mobile Architect</title>
   <meta name="description" content="Guillermo Rodriguez Delgado — iOS Software Engineer and Mobile Architect with 14+ years building high-quality, secure mobile software. Digital identity, SwiftUI, game dev.">
   <meta name="theme-color" content="#08080a">
+  <script>try{var t=localStorage.getItem('grd-theme');if(t)document.documentElement.setAttribute('data-theme',t);}catch(e){}</script>
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="Guillermo Rodriguez Delgado — iOS Engineer &amp; Mobile Architect">
@@ -33,6 +34,10 @@
       <div class="nav-status">
         <span class="status-dot">Available</span>
         <span class="clock" id="clock">--:--:--</span>
+        <button class="theme-toggle" id="themeToggle" type="button" aria-label="Switch between light and dark theme" title="Toggle theme">
+          <svg class="i-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12.74 2.02a9.5 9.5 0 1 0 9.24 12.23.75.75 0 0 0-.98-.9 7 7 0 0 1-8.83-8.83.75.75 0 0 0-.9-.98 9.6 9.6 0 0 0 1.47-.52z"/></svg>
+          <svg class="i-sun" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm0-5a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1zm0 16a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0v-2a1 1 0 0 1 1-1zM4.22 4.22a1 1 0 0 1 1.42 0l1.4 1.42A1 1 0 0 1 5.64 7.06L4.22 5.64a1 1 0 0 1 0-1.42zm12.72 12.72a1 1 0 0 1 1.42 0l1.42 1.42a1 1 0 0 1-1.42 1.42l-1.42-1.42a1 1 0 0 1 0-1.42zM2 12a1 1 0 0 1 1-1h2a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1zm16 0a1 1 0 0 1 1-1h2a1 1 0 1 1 0 2h-2a1 1 0 0 1-1-1zM4.22 19.78a1 1 0 0 1 0-1.42l1.42-1.42a1 1 0 0 1 1.42 1.42l-1.42 1.42a1 1 0 0 1-1.42 0zM16.94 7.06a1 1 0 0 1 0-1.42l1.42-1.42a1 1 0 1 1 1.42 1.42l-1.42 1.42a1 1 0 0 1-1.42 0z"/></svg>
+        </button>
       </div>
       <div class="scroll-progress" id="progress"></div>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy — Guillermo RD</title>
   <meta name="description" content="Privacy policy for apps published by Guillermo Rodriguez Delgado.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy — Guillermo RD</title>
-  <meta name="description" content="Privacy policy for apps published by Guillermo Rodriguez Delgado.">
+  <meta name="description" content="Privacy policy for apps published by Guillermo Rodríguez Delgado.">
   <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
@@ -27,7 +27,7 @@
       <p class="updated">Last updated: July 17, 2026</p>
 
       <p>This page describes the general privacy practices for apps published by
-      Guillermo Rodriguez Delgado ("I", "me"). Each app also has its own dedicated
+      Guillermo Rodríguez Delgado ("I", "me"). Each app also has its own dedicated
       privacy policy — see the app directory below for specifics.</p>
 
       <h2>General principles</h2>
@@ -72,7 +72,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 

--- a/privacy/other-app.html
+++ b/privacy/other-app.html
@@ -37,7 +37,7 @@
       <p class="updated">Last updated: July 17, 2026</p>
 
       <p>This privacy policy applies to the <strong>Other App</strong> app for iOS,
-      developed by Guillermo Rodriguez Delgado.</p>
+      developed by Guillermo Rodríguez Delgado.</p>
 
       <h2>Data collection</h2>
       <p>Other App does not collect, store or transmit any personal data. All app
@@ -74,7 +74,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 

--- a/privacy/other-app.html
+++ b/privacy/other-app.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Other App — Privacy Policy</title>
   <meta name="description" content="Privacy policy template for upcoming apps.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/privacy/sumo.html
+++ b/privacy/sumo.html
@@ -27,7 +27,7 @@
       <p class="updated">Last updated: July 17, 2026</p>
 
       <p>This privacy policy applies to the <strong>Sumo</strong> app for iOS,
-      developed by Guillermo Rodriguez Delgado.</p>
+      developed by Guillermo Rodríguez Delgado.</p>
 
       <h2>Data collection</h2>
       <p>Sumo does not collect personal data. There are no accounts, no ads and
@@ -80,7 +80,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 

--- a/privacy/sumo.html
+++ b/privacy/sumo.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sumo — Privacy Policy</title>
   <meta name="description" content="Privacy policy for the Sumo app.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/support/index.html
+++ b/support/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Support — Guillermo RD</title>
-  <meta name="description" content="Support and contact details for apps published by Guillermo Rodriguez Delgado.">
+  <meta name="description" content="Support and contact details for apps published by Guillermo Rodríguez Delgado.">
   <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
@@ -67,7 +67,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 

--- a/support/index.html
+++ b/support/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Support — Guillermo RD</title>
   <meta name="description" content="Support and contact details for apps published by Guillermo Rodriguez Delgado.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/support/other-app.html
+++ b/support/other-app.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Other App — Support</title>
   <meta name="description" content="Support page template for upcoming apps.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/support/other-app.html
+++ b/support/other-app.html
@@ -66,7 +66,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 

--- a/support/sumo.html
+++ b/support/sumo.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sumo — Support</title>
   <meta name="description" content="Support and contact details for the Sumo app.">
+  <script>try{var t=localStorage.getItem("grd-theme");if(t)document.documentElement.setAttribute("data-theme",t);}catch(e){}</script>
   <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 <body>

--- a/support/sumo.html
+++ b/support/sumo.html
@@ -61,7 +61,7 @@
         <a href="/privacy/">Privacy</a>
         <a href="/support/">Support</a>
       </nav>
-      <p>© 2026 Guillermo Rodriguez Delgado</p>
+      <p>© 2026 Guillermo Rodríguez Delgado</p>
     </div>
   </footer>
 


### PR DESCRIPTION
Complete ground-up redesign of the personal site around an F1 / running / urban-art inspired concept — an asphalt-black (or light concrete) canvas, a signature volt-green accent, and monospace telemetry framing.

## Highlights
- **New landing page** ("Telemetry"): HUD nav with scroll-progress bar, live Łódź clock and availability status; a kinetic hero with the poster-scale name and a typewriter role line; a timing-tower skills ticker; count-up stats; a "Dossier" about panel; a "Career Laps" timeline; a filterable "Garage" project grid; a "Spec Sheet" skills section; and a "Lights Out" contact block.
- **Portfolio screenshots** wired into the Garage as media headers (9 real device shots + on-brand telemetry placeholders for the rest), monochrome with a colour + Ken-Burns reveal on hover.
- **Light & dark themes**: follows `prefers-color-scheme` and can be overridden with a HUD toggle (persisted, no flash). Volt is kept in both themes — used as highlights with black foreground on light, neon on dark.
- **Name**: full "Guillermo Rodríguez Delgado" (accented í) in titles/meta/footers; the hero uses the two-line "Guillermo / R. Delgado".

## Housekeeping
- Compressed the nine Garage screenshots PNG → WebP (~3.3 MB → ~0.3 MB, lazy-loaded).
- Removed ~21 MB of unused legacy images from `assets/img`.
- Privacy/support pages restyled via the shared stylesheet and carry the theme preference.

## Notes
- Pure static (no build step); vanilla JS, Google Fonts (Anton / Space Grotesk / JetBrains Mono).
- Fully responsive and honours `prefers-reduced-motion`.
- Verified in-browser across both themes and breakpoints (hero, dossier, career, garage incl. filter + hover, contact, and the privacy page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143DJdC6Loo7NosGvoQJigG

---
_Generated by [Claude Code](https://claude.ai/code/session_0143DJdC6Loo7NosGvoQJigG)_